### PR TITLE
Change tag to playframework

### DIFF
--- a/activator.properties
+++ b/activator.properties
@@ -1,4 +1,4 @@
 name=play-spring-data-jpa
 title=Play with Spring Data Jpa
 description=This is a Play example that uses Spring Data Jpa (http://www.springsource.org/spring-data/jpa).
-tags=play,spring,data,jpa,dependency-injection,injection
+tags=playframework,spring,data,jpa,dependency-injection,injection


### PR DESCRIPTION
We want to use the Activator tag `playframework` for all Play related projects.
